### PR TITLE
Minor UI updates before AI implementation

### DIFF
--- a/chronolog/chronolog/AddEventViewController.swift
+++ b/chronolog/chronolog/AddEventViewController.swift
@@ -409,8 +409,37 @@ class AddEventViewController: UIViewController {
                 let requiredEndDate = startDatePicker.date.addingTimeInterval(picker.countDownDuration)
                 endDatePicker.setDate(requiredEndDate, animated: true)
                 endDatePicker.minimumDate = requiredEndDate
-
-                print("Duration enabled: Adjusted end date to \(requiredEndDate)")
+                
+                // Find the scroll view by traversing up the view hierarchy
+                var currentView = container as UIView
+                var scrollView: UIScrollView?
+                
+                while currentView.superview != nil {
+                    if let foundScrollView = currentView.superview as? UIScrollView {
+                        scrollView = foundScrollView
+                        break
+                    }
+                    currentView = currentView.superview!
+                }
+                
+                // Ensure we found the scroll view and handle the scrolling
+                if let scrollView = scrollView {
+                    // Force layout update
+                    scrollView.layoutIfNeeded()
+                    container.layoutIfNeeded()
+                    
+                    // Convert container's frame to scroll view's coordinate space
+                    let containerRect = container.convert(container.bounds, to: scrollView)
+                    let bottomOfContainer = containerRect.maxY // Add padding
+                    
+                    // Calculate new offset
+                    let newOffset = bottomOfContainer - scrollView.bounds.height
+                    if newOffset > scrollView.contentOffset.y {
+                        DispatchQueue.main.async {
+                            scrollView.setContentOffset(CGPoint(x: 0, y: newOffset), animated: true)
+                        }
+                    }
+                }
             }
         }
     }

--- a/chronolog/chronolog/Base.lproj/Main.storyboard
+++ b/chronolog/chronolog/Base.lproj/Main.storyboard
@@ -38,7 +38,7 @@
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ddc-Bj-4I4">
                                 <rect key="frame" x="163" y="448" width="66" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                <color key="backgroundColor" red="1" green="0.58546906403324639" blue="0.0072833478764917636" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" systemColor="systemBackgroundColor"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Login"/>
@@ -458,7 +458,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="W8Z-QO-TXd"/>
         <segue reference="8un-05-ZV9"/>
-        <segue reference="ful-wo-eRZ"/>
+        <segue reference="7hd-ug-JTv"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="arrowshape.turn.up.backward.fill" catalog="system" width="128" height="104"/>

--- a/chronolog/chronolog/CalendarViewController.swift
+++ b/chronolog/chronolog/CalendarViewController.swift
@@ -164,7 +164,8 @@ class CalendarViewController: DayViewController, UITabBarControllerDelegate {
             let midnight = Calendar.current.startOfDay(for: date)
             guard let nextMidnight = Calendar.current.date(byAdding: .day, value: 1, to: midnight) else { return }
             eventDescriptor.dateInterval = DateInterval(start: midnight, end: nextMidnight)
-            eventDescriptor.backgroundColor = .systemBlue
+//            eventDescriptor.backgroundColor = .systemBlue
+            eventDescriptor.backgroundColor = UIColor(hex: "#C87501")
         } else {
             // Handle timed events
             guard let startTime = event.startTime ?? event.date else { return }
@@ -320,3 +321,19 @@ class CalendarViewController: DayViewController, UITabBarControllerDelegate {
 }
 
 
+// Add UIColor extension for hex color support if not already present
+extension UIColor {
+    convenience init(hex: String) {
+        var hexString = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexString = hexString.replacingOccurrences(of: "#", with: "")
+        
+        var rgb: UInt64 = 0
+        Scanner(string: hexString).scanHexInt64(&rgb)
+        
+        let red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+        let green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+        let blue = CGFloat(rgb & 0x0000FF) / 255.0
+        
+        self.init(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+}


### PR DESCRIPTION
Change all day event color in calendar from blue to darker orange to match accent color. Force scroll the VC down to make the bottom of the container visible when the duration switch is toggled in the AddEventVC.